### PR TITLE
Fix hero name clipping at narrow viewports

### DIFF
--- a/app/components/ParticleName.jsx
+++ b/app/components/ParticleName.jsx
@@ -184,8 +184,10 @@ export default function ParticleName({ text = "JINOOK JUNG", fontFamily }) {
       octx.textBaseline = "middle";
       octx.font = `100px ${fontFamily}`;
       const base = octx.measureText(text).width || 1;
-      const fontPx = Math.min(((w * 0.92) / base) * 100, h * 0.74);
-      octx.font = `${fontPx * 1.33}px ${fontFamily}`;
+      // fit to the box: width never exceeds 92% (so the ends never clip),
+      // height capped so the word stays vertically centred
+      const fontPx = Math.min(((w * 0.92) / base) * 100, h * 0.98);
+      octx.font = `${fontPx}px ${fontFamily}`;
       octx.fillText(text, w / 2, h / 2 + fontPx * 0.04);
 
       const img = octx.getImageData(0, 0, w, h).data;

--- a/app/components/ParticleName.module.scss
+++ b/app/components/ParticleName.module.scss
@@ -2,6 +2,7 @@
   position: relative;
   display: inline-block;
   line-height: 1;
+  max-width: 100%;
 }
 
 .text {


### PR DESCRIPTION
## Summary
The hero particle name ("JINOOK JUNG") clipped at both ends below ~425px viewport width.

**Cause:** the rasterized text was fit to 92% of the canvas width but then re-scaled by 1.33×, pushing the ends ~22% past the canvas edge whenever width was the binding constraint (narrow screens). The wrap could also exceed the viewport.

**Fix:**
- Fit the text to the canvas width directly (no 1.33 over-scale); fold the size into the height cap so desktop sizing is unchanged.
- Add `max-width: 100%` to `.wrap` so the canvas never exceeds the viewport.

Verified at 320 / 375 / 1280px — the name renders fully without clipping, and desktop is unchanged.